### PR TITLE
H7 backend

### DIFF
--- a/src/db/migrations/004_add_usernames_to_friends.sql
+++ b/src/db/migrations/004_add_usernames_to_friends.sql
@@ -1,0 +1,11 @@
+-- H7: denormalizar usernames en la tabla friends para ordenar alfabéticamente
+-- sin necesidad de consultar el servicio de usuarios en el listado.
+-- El username del requester se almacena al crear la solicitud (del JWT del emisor).
+-- El username del addressee se almacena al aceptar la solicitud (del JWT del aceptante).
+
+ALTER TABLE friends ADD COLUMN IF NOT EXISTS requester_username VARCHAR(255) NULL;
+ALTER TABLE friends ADD COLUMN IF NOT EXISTS addressee_username VARCHAR(255) NULL;
+
+-- Índices para ORDER BY eficiente en el listado alfabético
+CREATE INDEX IF NOT EXISTS idx_friends_requester_username ON friends(requester_username);
+CREATE INDEX IF NOT EXISTS idx_friends_addressee_username ON friends(addressee_username);

--- a/src/modules/friends/__tests__/friends.service.test.js
+++ b/src/modules/friends/__tests__/friends.service.test.js
@@ -12,12 +12,15 @@ jest.mock('../friends.repository', () => ({
     softDeleteById: jest.fn(),
     getPendingRequesterIds: jest.fn(),
     getPendingRequests: jest.fn(),
+    getConfirmedFriends: jest.fn(),
   },
 }));
 
 const REQUESTER_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
 const ADDRESSEE_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
 const friends_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+const REQUESTER_USERNAME = 'requester_user';
+const ADDRESSEE_USERNAME = 'addressee_user';
 
 // ---------------------------------------------------------------------------
 // sendRequest
@@ -31,6 +34,7 @@ describe('friendsService.sendRequest', () => {
     friendsRepository.create.mockResolvedValue({
       id: friends_ID,
       requester_id: REQUESTER_ID,
+      requester_username: REQUESTER_USERNAME,
       addressee_id: ADDRESSEE_ID,
       status: 'pending',
     });
@@ -38,44 +42,44 @@ describe('friendsService.sendRequest', () => {
 
   // CA.1: no auto-solicitud
   it('lanza 400 si el usuario intenta enviarse una solicitud a sí mismo', async () => {
-    await expect(friendsService.sendRequest(REQUESTER_ID, REQUESTER_ID))
+    await expect(friendsService.sendRequest(REQUESTER_ID, REQUESTER_USERNAME, REQUESTER_ID))
       .rejects.toMatchObject({ statusCode: 400 });
   });
 
   it('lanza AppError al enviarse solicitud a sí mismo', async () => {
-    await expect(friendsService.sendRequest(REQUESTER_ID, REQUESTER_ID))
+    await expect(friendsService.sendRequest(REQUESTER_ID, REQUESTER_USERNAME, REQUESTER_ID))
       .rejects.toBeInstanceOf(AppError);
   });
 
   // CA.5: rate limit
   it('lanza 429 si el usuario superó el límite de 20 solicitudes por hora', async () => {
     friendsRepository.countRequestsInLastHour.mockResolvedValue(20);
-    await expect(friendsService.sendRequest(REQUESTER_ID, ADDRESSEE_ID))
+    await expect(friendsService.sendRequest(REQUESTER_ID, REQUESTER_USERNAME, ADDRESSEE_ID))
       .rejects.toMatchObject({ statusCode: 429 });
   });
 
   it('no lanza si el usuario envió exactamente 19 solicitudes (dentro del límite)', async () => {
     friendsRepository.countRequestsInLastHour.mockResolvedValue(19);
-    await expect(friendsService.sendRequest(REQUESTER_ID, ADDRESSEE_ID))
+    await expect(friendsService.sendRequest(REQUESTER_ID, REQUESTER_USERNAME, ADDRESSEE_ID))
       .resolves.toEqual({ message: 'Solicitud enviada' });
   });
 
   // CA.4: bloqueado — devuelve éxito genérico sin crear registro
   it('devuelve éxito genérico si el destinatario bloqueó al emisor', async () => {
     friendsRepository.isBlockedBy.mockResolvedValue(true);
-    const result = await friendsService.sendRequest(REQUESTER_ID, ADDRESSEE_ID);
+    const result = await friendsService.sendRequest(REQUESTER_ID, REQUESTER_USERNAME, ADDRESSEE_ID);
     expect(result).toEqual({ message: 'Solicitud enviada' });
   });
 
   it('no crea registro ni consulta findByPair si el destinatario bloqueó al emisor', async () => {
     friendsRepository.isBlockedBy.mockResolvedValue(true);
-    await friendsService.sendRequest(REQUESTER_ID, ADDRESSEE_ID);
+    await friendsService.sendRequest(REQUESTER_ID, REQUESTER_USERNAME, ADDRESSEE_ID);
     expect(friendsRepository.create).not.toHaveBeenCalled();
     expect(friendsRepository.findByPair).not.toHaveBeenCalled();
   });
 
   it('verifica el bloqueo en la dirección correcta (destinatario bloqueó al emisor)', async () => {
-    await friendsService.sendRequest(REQUESTER_ID, ADDRESSEE_ID);
+    await friendsService.sendRequest(REQUESTER_ID, REQUESTER_USERNAME, ADDRESSEE_ID);
     expect(friendsRepository.isBlockedBy).toHaveBeenCalledWith(ADDRESSEE_ID, REQUESTER_ID);
   });
 
@@ -87,7 +91,7 @@ describe('friendsService.sendRequest', () => {
       addressee_id: ADDRESSEE_ID,
       status: 'pending',
     });
-    await expect(friendsService.sendRequest(REQUESTER_ID, ADDRESSEE_ID))
+    await expect(friendsService.sendRequest(REQUESTER_ID, REQUESTER_USERNAME, ADDRESSEE_ID))
       .rejects.toMatchObject({ statusCode: 409 });
   });
 
@@ -99,7 +103,7 @@ describe('friendsService.sendRequest', () => {
       addressee_id: ADDRESSEE_ID,
       status: 'accepted',
     });
-    await expect(friendsService.sendRequest(REQUESTER_ID, ADDRESSEE_ID))
+    await expect(friendsService.sendRequest(REQUESTER_ID, REQUESTER_USERNAME, ADDRESSEE_ID))
       .rejects.toMatchObject({ statusCode: 409 });
   });
 
@@ -114,9 +118,9 @@ describe('friendsService.sendRequest', () => {
     friendsRepository.findByPair.mockResolvedValue(reversePending);
     friendsRepository.acceptById.mockResolvedValue({ ...reversePending, status: 'accepted' });
 
-    const result = await friendsService.sendRequest(REQUESTER_ID, ADDRESSEE_ID);
+    const result = await friendsService.sendRequest(REQUESTER_ID, REQUESTER_USERNAME, ADDRESSEE_ID);
     expect(result).toEqual({ message: 'Solicitud enviada' });
-    expect(friendsRepository.acceptById).toHaveBeenCalledWith(friends_ID);
+    expect(friendsRepository.acceptById).toHaveBeenCalledWith(friends_ID, REQUESTER_USERNAME);
   });
 
   it('no crea nuevo registro al auto-aceptar solicitud inversa (CA.3)', async () => {
@@ -128,18 +132,18 @@ describe('friendsService.sendRequest', () => {
     });
     friendsRepository.acceptById.mockResolvedValue({});
 
-    await friendsService.sendRequest(REQUESTER_ID, ADDRESSEE_ID);
+    await friendsService.sendRequest(REQUESTER_ID, REQUESTER_USERNAME, ADDRESSEE_ID);
     expect(friendsRepository.create).not.toHaveBeenCalled();
   });
 
   // CA.2: crea solicitud pendiente en el caso exitoso normal
   it('crea la solicitud en estado pendiente cuando todo está en orden', async () => {
-    await friendsService.sendRequest(REQUESTER_ID, ADDRESSEE_ID);
-    expect(friendsRepository.create).toHaveBeenCalledWith(REQUESTER_ID, ADDRESSEE_ID);
+    await friendsService.sendRequest(REQUESTER_ID, REQUESTER_USERNAME, ADDRESSEE_ID);
+    expect(friendsRepository.create).toHaveBeenCalledWith(REQUESTER_ID, REQUESTER_USERNAME, ADDRESSEE_ID);
   });
 
   it('devuelve mensaje de éxito al crear la solicitud', async () => {
-    const result = await friendsService.sendRequest(REQUESTER_ID, ADDRESSEE_ID);
+    const result = await friendsService.sendRequest(REQUESTER_ID, REQUESTER_USERNAME, ADDRESSEE_ID);
     expect(result).toEqual({ message: 'Solicitud enviada' });
   });
 });
@@ -154,19 +158,19 @@ describe('friendsService.acceptRequest', () => {
 
   // Error: auto-aceptación
   it('lanza 400 si el usuario intenta aceptar su propia solicitud', async () => {
-    await expect(friendsService.acceptRequest(REQUESTER_ID, REQUESTER_ID))
+    await expect(friendsService.acceptRequest(REQUESTER_ID, REQUESTER_USERNAME, REQUESTER_ID))
       .rejects.toMatchObject({ statusCode: 400 });
   });
 
   it('lanza AppError si el usuario intenta aceptar su propia solicitud', async () => {
-    await expect(friendsService.acceptRequest(REQUESTER_ID, REQUESTER_ID))
+    await expect(friendsService.acceptRequest(REQUESTER_ID, REQUESTER_USERNAME, REQUESTER_ID))
       .rejects.toBeInstanceOf(AppError);
   });
 
   // No existe ninguna relación
   it('lanza 409 si no existe ninguna solicitud entre los dos usuarios', async () => {
     friendsRepository.findByPair.mockResolvedValue(null);
-    await expect(friendsService.acceptRequest(REQUESTER_ID, ADDRESSEE_ID))
+    await expect(friendsService.acceptRequest(REQUESTER_ID, REQUESTER_USERNAME, ADDRESSEE_ID))
       .rejects.toMatchObject({ statusCode: 409 });
   });
 
@@ -182,12 +186,13 @@ describe('friendsService.acceptRequest', () => {
       id: friends_ID,
       requester_id: ADDRESSEE_ID,
       addressee_id: REQUESTER_ID,
+      addressee_username: REQUESTER_USERNAME,
       status: 'accepted',
     });
 
-    const result = await friendsService.acceptRequest(REQUESTER_ID, ADDRESSEE_ID);
+    const result = await friendsService.acceptRequest(REQUESTER_ID, REQUESTER_USERNAME, ADDRESSEE_ID);
     expect(result).toEqual({ message: 'Solicitud aceptada' });
-    expect(friendsRepository.acceptById).toHaveBeenCalledWith(friends_ID);
+    expect(friendsRepository.acceptById).toHaveBeenCalledWith(friends_ID, REQUESTER_USERNAME);
   });
 
   // La solicitud está en la dirección incorrecta
@@ -199,7 +204,7 @@ describe('friendsService.acceptRequest', () => {
       status: 'pending',
     });
 
-    await expect(friendsService.acceptRequest(REQUESTER_ID, ADDRESSEE_ID))
+    await expect(friendsService.acceptRequest(REQUESTER_ID, REQUESTER_USERNAME, ADDRESSEE_ID))
       .rejects.toMatchObject({ statusCode: 409 });
   });
 
@@ -212,12 +217,12 @@ describe('friendsService.acceptRequest', () => {
       status: 'accepted',
     });
 
-    await expect(friendsService.acceptRequest(REQUESTER_ID, ADDRESSEE_ID))
+    await expect(friendsService.acceptRequest(REQUESTER_ID, REQUESTER_USERNAME, ADDRESSEE_ID))
       .rejects.toMatchObject({ statusCode: 409 });
   });
 
-  // Llama a acceptById con el id correcto
-  it('llama a acceptById con el ID de la relación', async () => {
+  // Llama a acceptById con el id y username correctos
+  it('llama a acceptById con el ID de la relación y el username del aceptante', async () => {
     friendsRepository.findByPair.mockResolvedValue({
       id: friends_ID,
       requester_id: ADDRESSEE_ID,
@@ -226,9 +231,9 @@ describe('friendsService.acceptRequest', () => {
     });
     friendsRepository.acceptById.mockResolvedValue({});
 
-    await friendsService.acceptRequest(REQUESTER_ID, ADDRESSEE_ID);
+    await friendsService.acceptRequest(REQUESTER_ID, REQUESTER_USERNAME, ADDRESSEE_ID);
     expect(friendsRepository.acceptById).toHaveBeenCalledTimes(1);
-    expect(friendsRepository.acceptById).toHaveBeenCalledWith(friends_ID);
+    expect(friendsRepository.acceptById).toHaveBeenCalledWith(friends_ID, REQUESTER_USERNAME);
   });
 });
 
@@ -469,5 +474,125 @@ describe('friendsService.getPendingRequests', () => {
     const result = await friendsService.getPendingRequests(ADDRESSEE_ID, 1);
 
     expect(result.pagination.pageSize).toBe(20);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getFriendsList — H7 CA.1, CA.2
+// ---------------------------------------------------------------------------
+describe('friendsService.getFriendsList', () => {
+  const THIRD_USER_ID = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+
+  const makeFriend = (friendId, friendUsername, totalCount = '1') => ({
+    friend_id: friendId,
+    friend_username: friendUsername,
+    total_count: totalCount,
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // CA.2: lista vacía
+  it('CA.2: devuelve lista vacía y paginación cero si no tiene amigos', async () => {
+    friendsRepository.getConfirmedFriends.mockResolvedValue({ rows: [], total: 0 });
+
+    const result = await friendsService.getFriendsList(REQUESTER_ID, 'alphabetical', 1);
+
+    expect(result).toEqual({
+      data: [],
+      pagination: { page: 1, pageSize: 20, total: 0, totalPages: 0 },
+    });
+  });
+
+  // CA.1: orden alfabético
+  it('CA.1: llama al repository con los parámetros correctos para orden alfabético (page 1)', async () => {
+    friendsRepository.getConfirmedFriends.mockResolvedValue({
+      rows: [makeFriend(ADDRESSEE_ID, 'alice')],
+      total: 1,
+    });
+
+    await friendsService.getFriendsList(REQUESTER_ID, 'alphabetical', 1);
+
+    expect(friendsRepository.getConfirmedFriends).toHaveBeenCalledWith(
+      REQUESTER_ID,
+      20,  // limit = PAGE_SIZE
+      0    // offset = (1 - 1) * 20
+    );
+  });
+
+  it('CA.1: usa sortBy alphabetical por defecto si no se pasa parámetro', async () => {
+    friendsRepository.getConfirmedFriends.mockResolvedValue({ rows: [], total: 0 });
+
+    await friendsService.getFriendsList(REQUESTER_ID);
+
+    expect(friendsRepository.getConfirmedFriends).toHaveBeenCalledWith(REQUESTER_ID, 20, 0);
+  });
+
+  // CA.1: proximidad → 501
+  it('CA.1: lanza 501 si sortBy es proximity (servicio de ubicaciones no disponible)', async () => {
+    await expect(friendsService.getFriendsList(REQUESTER_ID, 'proximity', 1))
+      .rejects.toMatchObject({ statusCode: 501 });
+  });
+
+  it('CA.1: lanza AppError al pedir sortBy proximity', async () => {
+    await expect(friendsService.getFriendsList(REQUESTER_ID, 'proximity', 1))
+      .rejects.toBeInstanceOf(AppError);
+  });
+
+  it('CA.1: no consulta el repository si sortBy es proximity', async () => {
+    await friendsService.getFriendsList(REQUESTER_ID, 'proximity', 1).catch(() => {});
+    expect(friendsRepository.getConfirmedFriends).not.toHaveBeenCalled();
+  });
+
+  // CA.2: paginación
+  it('CA.2: calcula offset correctamente para páginas mayores a 1', async () => {
+    friendsRepository.getConfirmedFriends.mockResolvedValue({ rows: [], total: 25 });
+
+    await friendsService.getFriendsList(REQUESTER_ID, 'alphabetical', 2);
+
+    expect(friendsRepository.getConfirmedFriends).toHaveBeenCalledWith(
+      REQUESTER_ID,
+      20,  // limit
+      20   // offset = (2 - 1) * 20
+    );
+  });
+
+  it('CA.2: devuelve totalPages correcto cuando hay más de 20 amigos', async () => {
+    friendsRepository.getConfirmedFriends.mockResolvedValue({ rows: [], total: 25 });
+
+    const result = await friendsService.getFriendsList(REQUESTER_ID, 'alphabetical', 1);
+
+    expect(result.pagination).toEqual({
+      page: 1,
+      pageSize: 20,
+      total: 25,
+      totalPages: 2,
+    });
+  });
+
+  it('CA.2: devuelve totalPages = 1 cuando hay exactamente 20 amigos', async () => {
+    friendsRepository.getConfirmedFriends.mockResolvedValue({ rows: [], total: 20 });
+
+    const result = await friendsService.getFriendsList(REQUESTER_ID, 'alphabetical', 1);
+
+    expect(result.pagination.totalPages).toBe(1);
+  });
+
+  it('CA.2: devuelve los datos del amigo tal como los provee el repository', async () => {
+    const friend = makeFriend(ADDRESSEE_ID, 'alice');
+    friendsRepository.getConfirmedFriends.mockResolvedValue({ rows: [friend], total: 1 });
+
+    const result = await friendsService.getFriendsList(REQUESTER_ID, 'alphabetical', 1);
+
+    expect(result.data).toEqual([friend]);
+  });
+
+  it('CA.2: usa page 1 por defecto si no se pasa parámetro', async () => {
+    friendsRepository.getConfirmedFriends.mockResolvedValue({ rows: [], total: 0 });
+
+    const result = await friendsService.getFriendsList(REQUESTER_ID);
+
+    expect(result.pagination.page).toBe(1);
   });
 });

--- a/src/modules/friends/friends.controller.js
+++ b/src/modules/friends/friends.controller.js
@@ -3,8 +3,12 @@ const { friendsService } = require('./friends.service');
 const friendsController = {
   async sendRequest(req, res, next) {
     try {
-      // req.user.sub viene del JWT verificado por el middleware authenticate
-      const result = await friendsService.sendRequest(req.user.sub, req.body.addresseeId);
+      // req.user.sub y req.user.username vienen del JWT verificado por authenticate
+      const result = await friendsService.sendRequest(
+        req.user.sub,
+        req.user.username,
+        req.body.addresseeId
+      );
       res.status(200).json(result);
     } catch (err) {
       next(err);
@@ -13,7 +17,11 @@ const friendsController = {
 
   async acceptRequest(req, res, next) {
     try {
-      const result = await friendsService.acceptRequest(req.user.sub, req.body.requesterId);
+      const result = await friendsService.acceptRequest(
+        req.user.sub,
+        req.user.username,
+        req.body.requesterId
+      );
       res.status(200).json(result);
     } catch (err) {
       next(err);
@@ -33,6 +41,19 @@ const friendsController = {
     try {
       const page = parseInt(req.query.page, 10) || 1;
       const result = await friendsService.getPendingRequests(req.user.sub, page);
+      res.status(200).json(result);
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  // H7: lista de amigos confirmados, paginada y ordenada.
+  // sortBy: 'alphabetical' (default) | 'proximity' (501 hasta integrar ubicaciones)
+  async getFriendsList(req, res, next) {
+    try {
+      const page = parseInt(req.query.page, 10) || 1;
+      const sortBy = req.query.sortBy || 'alphabetical';
+      const result = await friendsService.getFriendsList(req.user.sub, sortBy, page);
       res.status(200).json(result);
     } catch (err) {
       next(err);

--- a/src/modules/friends/friends.repository.js
+++ b/src/modules/friends/friends.repository.js
@@ -32,25 +32,27 @@ const friendsRepository = {
     return result.rows.length > 0;
   },
 
-  // Crea solicitud en estado pendiente
-  async create(requesterId, addresseeId) {
+  // Crea solicitud en estado pendiente almacenando el username del emisor (del JWT).
+  // El username del destinatario se guarda al aceptar (ver acceptById).
+  async create(requesterId, requesterUsername, addresseeId) {
     const result = await query(
-      `INSERT INTO friends (requester_id, addressee_id, status)
-       VALUES ($1, $2, 'pending')
+      `INSERT INTO friends (requester_id, requester_username, addressee_id, status)
+       VALUES ($1, $2, $3, 'pending')
        RETURNING *`,
-      [requesterId, addresseeId]
+      [requesterId, requesterUsername, addresseeId]
     );
     return result.rows[0];
   },
 
-  // Acepta la solicitud actualizando el status a 'accepted'
-  async acceptById(friendsId) {
+  // Acepta la solicitud actualizando el status a 'accepted' y guardando el
+  // username del aceptante (addressee de la solicitud original, del JWT).
+  async acceptById(friendsId, addresseeUsername) {
     const result = await query(
       `UPDATE friends
-       SET status = 'accepted', updated_at = NOW()
+       SET status = 'accepted', updated_at = NOW(), addressee_username = $2
        WHERE id = $1
        RETURNING *`,
-      [friendsId]
+      [friendsId, addresseeUsername]
     );
     return result.rows[0];
   },
@@ -78,6 +80,30 @@ const friendsRepository = {
       [addresseeId]
     );
     return result.rows.map((r) => r.requester_id);
+  },
+
+  // H7: devuelve amigos confirmados con su username, ordenados alfabéticamente.
+  // Usa CASE para obtener los datos del amigo (el que NO es userId) en cada fila.
+  // NULLS LAST para tolerar filas antiguas sin username migrado.
+  async getConfirmedFriends(userId, limit, offset) {
+    const result = await query(
+      `SELECT
+         CASE WHEN requester_id = $1 THEN addressee_id    ELSE requester_id    END AS friend_id,
+         CASE WHEN requester_id = $1 THEN addressee_username ELSE requester_username END AS friend_username,
+         COUNT(*) OVER() AS total_count
+       FROM friends
+       WHERE (requester_id = $1 OR addressee_id = $1)
+         AND status = 'accepted'
+         AND deleted_at IS NULL
+       ORDER BY
+         CASE WHEN requester_id = $1 THEN addressee_username ELSE requester_username END ASC NULLS LAST
+       LIMIT $2 OFFSET $3`,
+      [userId, limit, offset]
+    );
+    const total = result.rows[0]?.total_count
+      ? parseInt(result.rows[0].total_count, 10)
+      : 0;
+    return { rows: result.rows, total };
   },
 
   // CA.3/CA.5: devuelve solicitudes pendientes paginadas, filtradas por emisores activos.

--- a/src/modules/friends/friends.routes.js
+++ b/src/modules/friends/friends.routes.js
@@ -19,4 +19,8 @@ router.post('/decline', authenticate, validate(declineRequestSchema), friendsCon
 // CA.3: ordenadas cronológicamente desc | CA.4: filtra usuarios inactivos | CA.5: paginado
 router.get('/pending', authenticate, friendsController.getPendingRequests);
 
+// GET /api/friends?page=1&sortBy=alphabetical|proximity
+// H7 CA.1: lista de amigos confirmados ordenada | CA.2: paginada (20 por página)
+router.get('/', authenticate, friendsController.getFriendsList);
+
 module.exports = router;

--- a/src/modules/friends/friends.service.js
+++ b/src/modules/friends/friends.service.js
@@ -5,7 +5,8 @@ const REQUEST_LIMIT_PER_HOUR = 20;
 const PAGE_SIZE = 20;
 
 const friendsService = {
-  async sendRequest(requesterId, addresseeId) {
+  // requesterUsername: username del usuario actual (del JWT), se persiste en la fila.
+  async sendRequest(requesterId, requesterUsername, addresseeId) {
     // CA.1: no auto-solicitud
     if (requesterId === addresseeId) {
       throw new AppError(400, 'No podés enviarte una solicitud a vos mismo');
@@ -26,13 +27,15 @@ const friendsService = {
     // CA.1 + CA.3: verificar si ya existe relación en alguna dirección
     const existing = await friendsRepository.findByPair(requesterId, addresseeId);
     if (existing) {
-      // CA.3: B ya había enviado solicitud a A (pendiente) — aceptar automáticamente
+      // CA.3: B ya había enviado solicitud a A (pendiente) — aceptar automáticamente.
+      // El usuario actual (requesterId) es el addressee de la fila existente,
+      // así que su username va en addressee_username.
       if (
         existing.status === 'pending' &&
         existing.requester_id === addresseeId &&
         existing.addressee_id === requesterId
       ) {
-        await friendsRepository.acceptById(existing.id);
+        await friendsRepository.acceptById(existing.id, requesterUsername);
         return { message: 'Solicitud enviada' };
       }
 
@@ -41,11 +44,12 @@ const friendsService = {
     }
 
     // CA.2: crear solicitud pendiente
-    await friendsRepository.create(requesterId, addresseeId);
+    await friendsRepository.create(requesterId, requesterUsername, addresseeId);
     return { message: 'Solicitud enviada' };
   },
 
-  async acceptRequest(requesterId, addresseeId) {
+  // requesterUsername: username del usuario actual (el aceptante, addressee de la fila).
+  async acceptRequest(requesterId, requesterUsername, addresseeId) {
     // CA.1: no auto-aceptación
     if (requesterId === addresseeId) {
       throw new AppError(400, 'No podés aceptar una solicitud de vos mismo');
@@ -60,7 +64,7 @@ const friendsService = {
       existing.requester_id === addresseeId &&
       existing.addressee_id === requesterId
     ) {
-      await friendsRepository.acceptById(existing.id);
+      await friendsRepository.acceptById(existing.id, requesterUsername);
       return { message: 'Solicitud aceptada' };
     }
 
@@ -93,6 +97,30 @@ const friendsService = {
     }
 
     throw new AppError(409, 'No existe una solicitud de amistad válida para rechazar');
+  },
+
+  // H7 CA.1: lista paginada de amigos confirmados.
+  // sortBy='alphabetical': ordena por username del amigo (A-Z).
+  // sortBy='proximity': devuelve 501 — requiere integración con servicio de ubicaciones (pendiente).
+  async getFriendsList(userId, sortBy = 'alphabetical', page = 1) {
+    if (sortBy === 'proximity') {
+      throw new AppError(501, 'Ordenamiento por cercanía aún no está disponible');
+    }
+
+    const limit = PAGE_SIZE;
+    const offset = (page - 1) * limit;
+
+    const { rows, total } = await friendsRepository.getConfirmedFriends(userId, limit, offset);
+
+    return {
+      data: rows,
+      pagination: {
+        page,
+        pageSize: limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
   },
 
   // CA.3/CA.5: lista paginada de solicitudes pendientes ordenadas descendente.


### PR DESCRIPTION
Lógica de visualizacion de lista de amigos (backend). Suma una nueva migracion para tener username del requester y addressee en la base de datos. Se puede pedir la lista de amigos ordenada alfabeticamente o por cercania desde el endpoint: `sortBy=alphabetical|proximity `. `proximity` todavía no esta implementado por dependencias con el servicio ubicaciones, por lo que devuelve `501 Not Implemented`. Suma el endpoint `GET /api/friends?page=1&sortBy=alphabetical `