### PR TITLE
H8 Parcial

### DIFF
--- a/src/modules/friends/__tests__/friends.service.test.js
+++ b/src/modules/friends/__tests__/friends.service.test.js
@@ -12,6 +12,10 @@ jest.mock('../friends.repository', () => ({
     softDeleteById: jest.fn(),
     getPendingRequesterIds: jest.fn(),
     getPendingRequests: jest.fn(),
+    createBlock: jest.fn(),
+    deleteBlock: jest.fn(),
+    getBlockedUserIds: jest.fn(),
+    softDeleteFriendshipByPair: jest.fn(),
   },
 }));
 
@@ -469,5 +473,179 @@ describe('friendsService.getPendingRequests', () => {
     const result = await friendsService.getPendingRequests(ADDRESSEE_ID, 1);
 
     expect(result.pagination.pageSize).toBe(20);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// blockUser — H8
+// ---------------------------------------------------------------------------
+describe('friendsService.blockUser', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    friendsRepository.createBlock.mockResolvedValue({
+      id: friends_ID,
+      blocker_id: REQUESTER_ID,
+      blocked_id: ADDRESSEE_ID,
+      created_at: new Date(),
+    });
+    friendsRepository.softDeleteFriendshipByPair.mockResolvedValue(null);
+  });
+
+  it('lanza 400 si el usuario intenta bloquearse a sí mismo', async () => {
+    await expect(friendsService.blockUser(REQUESTER_ID, REQUESTER_ID))
+      .rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it('lanza AppError si el usuario intenta bloquearse a sí mismo', async () => {
+    await expect(friendsService.blockUser(REQUESTER_ID, REQUESTER_ID))
+      .rejects.toBeInstanceOf(AppError);
+  });
+
+  it('llama a createBlock con los parámetros correctos', async () => {
+    await friendsService.blockUser(REQUESTER_ID, ADDRESSEE_ID);
+    expect(friendsRepository.createBlock).toHaveBeenCalledWith(REQUESTER_ID, ADDRESSEE_ID);
+    expect(friendsRepository.createBlock).toHaveBeenCalledTimes(1);
+  });
+
+  // CA.3: debe romper la amistad existente al bloquear
+  it('CA.3: llama a softDeleteFriendshipByPair para romper la amistad existente', async () => {
+    await friendsService.blockUser(REQUESTER_ID, ADDRESSEE_ID);
+    expect(friendsRepository.softDeleteFriendshipByPair).toHaveBeenCalledWith(REQUESTER_ID, ADDRESSEE_ID);
+    expect(friendsRepository.softDeleteFriendshipByPair).toHaveBeenCalledTimes(1);
+  });
+
+  // CA.3: también se ejecuta aunque no hubiera amistad (softDeleteFriendshipByPair devuelve null)
+  it('CA.3: llama a softDeleteFriendshipByPair aunque no existiera amistad previa', async () => {
+    friendsRepository.softDeleteFriendshipByPair.mockResolvedValue(null);
+    await expect(friendsService.blockUser(REQUESTER_ID, ADDRESSEE_ID)).resolves.toBeDefined();
+    expect(friendsRepository.softDeleteFriendshipByPair).toHaveBeenCalled();
+  });
+
+  it('devuelve mensaje de éxito al bloquear correctamente', async () => {
+    const result = await friendsService.blockUser(REQUESTER_ID, ADDRESSEE_ID);
+    expect(result).toEqual({ message: 'Usuario bloqueado' });
+  });
+
+  // Idempotencia: bloquear a alguien ya bloqueado no falla (createBlock usa ON CONFLICT DO NOTHING)
+  it('no lanza error si el usuario ya estaba bloqueado (idempotente)', async () => {
+    friendsRepository.createBlock.mockResolvedValue(null); // ON CONFLICT DO NOTHING devuelve null
+    await expect(friendsService.blockUser(REQUESTER_ID, ADDRESSEE_ID)).resolves.toEqual({ message: 'Usuario bloqueado' });
+  });
+
+  // CA.1: no se notifica al bloqueado — el servicio no llama a ningún método de notificación
+  it('CA.1: no llama a ningún método de notificación (no hay notify/send en el flujo)', async () => {
+    await friendsService.blockUser(REQUESTER_ID, ADDRESSEE_ID);
+    // Verificamos que solo se llaman los métodos esperados del repositorio
+    expect(friendsRepository.countRequestsInLastHour).not.toHaveBeenCalled();
+    expect(friendsRepository.isBlockedBy).not.toHaveBeenCalled();
+    expect(friendsRepository.findByPair).not.toHaveBeenCalled();
+    expect(friendsRepository.create).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// unblockUser — H8 CA.2
+// ---------------------------------------------------------------------------
+describe('friendsService.unblockUser', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    friendsRepository.deleteBlock.mockResolvedValue({
+      id: friends_ID,
+      blocker_id: REQUESTER_ID,
+      blocked_id: ADDRESSEE_ID,
+    });
+  });
+
+  it('lanza 400 si el usuario pasa su propio ID como blockedId', async () => {
+    await expect(friendsService.unblockUser(REQUESTER_ID, REQUESTER_ID))
+      .rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it('lanza AppError si el usuario pasa su propio ID como blockedId', async () => {
+    await expect(friendsService.unblockUser(REQUESTER_ID, REQUESTER_ID))
+      .rejects.toBeInstanceOf(AppError);
+  });
+
+  it('lanza 404 si no existía el bloqueo', async () => {
+    friendsRepository.deleteBlock.mockResolvedValue(null);
+    await expect(friendsService.unblockUser(REQUESTER_ID, ADDRESSEE_ID))
+      .rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it('lanza AppError si no existía el bloqueo', async () => {
+    friendsRepository.deleteBlock.mockResolvedValue(null);
+    await expect(friendsService.unblockUser(REQUESTER_ID, ADDRESSEE_ID))
+      .rejects.toBeInstanceOf(AppError);
+  });
+
+  it('llama a deleteBlock con los parámetros correctos', async () => {
+    await friendsService.unblockUser(REQUESTER_ID, ADDRESSEE_ID);
+    expect(friendsRepository.deleteBlock).toHaveBeenCalledWith(REQUESTER_ID, ADDRESSEE_ID);
+    expect(friendsRepository.deleteBlock).toHaveBeenCalledTimes(1);
+  });
+
+  it('devuelve mensaje de éxito al desbloquear correctamente', async () => {
+    const result = await friendsService.unblockUser(REQUESTER_ID, ADDRESSEE_ID);
+    expect(result).toEqual({ message: 'Usuario desbloqueado' });
+  });
+
+  // El desbloqueo no restaura la amistad — es responsabilidad del usuario reenviar solicitud
+  it('no llama a softDeleteFriendshipByPair ni a createBlock al desbloquear', async () => {
+    await friendsService.unblockUser(REQUESTER_ID, ADDRESSEE_ID);
+    expect(friendsRepository.softDeleteFriendshipByPair).not.toHaveBeenCalled();
+    expect(friendsRepository.createBlock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getBlockedUsers — H8 CA.2
+// ---------------------------------------------------------------------------
+describe('friendsService.getBlockedUsers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('devuelve lista vacía si el usuario no tiene bloqueados', async () => {
+    friendsRepository.getBlockedUserIds.mockResolvedValue([]);
+    const result = await friendsService.getBlockedUsers(REQUESTER_ID);
+    expect(result).toEqual({ data: [] });
+  });
+
+  it('devuelve la lista de bloqueados con sus IDs y fechas', async () => {
+    const blocked = [
+      { blocked_id: ADDRESSEE_ID, created_at: new Date('2024-06-01') },
+    ];
+    friendsRepository.getBlockedUserIds.mockResolvedValue(blocked);
+
+    const result = await friendsService.getBlockedUsers(REQUESTER_ID);
+    expect(result).toEqual({ data: blocked });
+  });
+
+  it('devuelve múltiples bloqueados correctamente', async () => {
+    const THIRD_USER_ID = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    const blocked = [
+      { blocked_id: ADDRESSEE_ID, created_at: new Date('2024-06-02') },
+      { blocked_id: THIRD_USER_ID, created_at: new Date('2024-06-01') },
+    ];
+    friendsRepository.getBlockedUserIds.mockResolvedValue(blocked);
+
+    const result = await friendsService.getBlockedUsers(REQUESTER_ID);
+    expect(result.data).toHaveLength(2);
+    expect(result.data).toEqual(blocked);
+  });
+
+  it('llama a getBlockedUserIds con el ID del bloqueador correcto', async () => {
+    friendsRepository.getBlockedUserIds.mockResolvedValue([]);
+    await friendsService.getBlockedUsers(REQUESTER_ID);
+    expect(friendsRepository.getBlockedUserIds).toHaveBeenCalledWith(REQUESTER_ID);
+    expect(friendsRepository.getBlockedUserIds).toHaveBeenCalledTimes(1);
+  });
+
+  it('no llama a ningún otro método del repositorio', async () => {
+    friendsRepository.getBlockedUserIds.mockResolvedValue([]);
+    await friendsService.getBlockedUsers(REQUESTER_ID);
+    expect(friendsRepository.findByPair).not.toHaveBeenCalled();
+    expect(friendsRepository.createBlock).not.toHaveBeenCalled();
+    expect(friendsRepository.deleteBlock).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/friends/friends.controller.js
+++ b/src/modules/friends/friends.controller.js
@@ -1,4 +1,7 @@
 const { friendsService } = require('./friends.service');
+const { AppError } = require('../../middlewares/errorHandler');
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 const friendsController = {
   async sendRequest(req, res, next) {
@@ -23,6 +26,36 @@ const friendsController = {
   async declineRequest(req, res, next) {
     try {
       const result = await friendsService.declineRequest(req.user.sub, req.body.requesterId);
+      res.status(200).json(result);
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async blockUser(req, res, next) {
+    try {
+      const result = await friendsService.blockUser(req.user.sub, req.body.blockedId);
+      res.status(200).json(result);
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async unblockUser(req, res, next) {
+    try {
+      if (!UUID_REGEX.test(req.params.blockedId)) {
+        throw new AppError(400, 'El ID del usuario no es válido');
+      }
+      const result = await friendsService.unblockUser(req.user.sub, req.params.blockedId);
+      res.status(200).json(result);
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async getBlockedUsers(req, res, next) {
+    try {
+      const result = await friendsService.getBlockedUsers(req.user.sub);
       res.status(200).json(result);
     } catch (err) {
       next(err);

--- a/src/modules/friends/friends.repository.js
+++ b/src/modules/friends/friends.repository.js
@@ -99,6 +99,53 @@ const friendsRepository = {
       : 0;
     return { rows: result.rows, total };
   },
+
+  // H8: crea un bloqueo de blockerId hacia blockedId.
+  // ON CONFLICT DO NOTHING hace la operación idempotente: bloquear dos veces no es error.
+  async createBlock(blockerId, blockedId) {
+    const result = await query(
+      `INSERT INTO blocks (blocker_id, blocked_id)
+       VALUES ($1, $2)
+       ON CONFLICT (blocker_id, blocked_id) DO NOTHING
+       RETURNING *`,
+      [blockerId, blockedId]
+    );
+    return result.rows[0] ?? null;
+  },
+
+  // H8: elimina el bloqueo de blockerId hacia blockedId.
+  // Devuelve null si no existía el bloqueo.
+  async deleteBlock(blockerId, blockedId) {
+    const result = await query(
+      `DELETE FROM blocks WHERE blocker_id = $1 AND blocked_id = $2 RETURNING *`,
+      [blockerId, blockedId]
+    );
+    return result.rows[0] ?? null;
+  },
+
+  // H8 CA.2: lista todos los usuarios bloqueados por blockerId, ordenados por fecha descendente.
+  async getBlockedUserIds(blockerId) {
+    const result = await query(
+      `SELECT blocked_id, created_at FROM blocks WHERE blocker_id = $1 ORDER BY created_at DESC`,
+      [blockerId]
+    );
+    return result.rows;
+  },
+
+  // H8 CA.3: soft-delete de la amistad entre userAId y userBId en cualquier dirección.
+  // Se ejecuta al bloquear para romper automáticamente relaciones pendientes o aceptadas.
+  async softDeleteFriendshipByPair(userAId, userBId) {
+    const result = await query(
+      `UPDATE friends
+       SET deleted_at = NOW(), updated_at = NOW()
+       WHERE ((requester_id = $1 AND addressee_id = $2)
+           OR (requester_id = $2 AND addressee_id = $1))
+         AND deleted_at IS NULL
+       RETURNING *`,
+      [userAId, userBId]
+    );
+    return result.rows[0] ?? null;
+  },
 };
 
 module.exports = { friendsRepository };

--- a/src/modules/friends/friends.routes.js
+++ b/src/modules/friends/friends.routes.js
@@ -2,7 +2,7 @@ const { Router } = require('express');
 const { friendsController } = require('./friends.controller');
 const { validate } = require('../../middlewares/validate');
 const { authenticate } = require('../../middlewares/authenticate');
-const { sendRequestSchema, acceptRequestSchema, declineRequestSchema } = require('./friends.schemas');
+const { sendRequestSchema, acceptRequestSchema, declineRequestSchema, blockUserSchema } = require('./friends.schemas');
 
 const router = Router();
 
@@ -18,5 +18,17 @@ router.post('/decline', authenticate, validate(declineRequestSchema), friendsCon
 // GET /api/friends/pending?page=1
 // CA.3: ordenadas cronológicamente desc | CA.4: filtra usuarios inactivos | CA.5: paginado
 router.get('/pending', authenticate, friendsController.getPendingRequests);
+
+// H8: Bloquear usuario
+// POST /api/friends/block
+router.post('/block', authenticate, validate(blockUserSchema), friendsController.blockUser);
+
+// H8 CA.2: Desbloquear usuario
+// DELETE /api/friends/block/:blockedId
+router.delete('/block/:blockedId', authenticate, friendsController.unblockUser);
+
+// H8 CA.2: Listar bloqueados
+// GET /api/friends/blocks
+router.get('/blocks', authenticate, friendsController.getBlockedUsers);
 
 module.exports = router;

--- a/src/modules/friends/friends.schemas.js
+++ b/src/modules/friends/friends.schemas.js
@@ -20,4 +20,10 @@ const declineRequestSchema = z.object({
     .uuid('El ID del solicitante no es válido'),
 });
 
-module.exports = { sendRequestSchema, acceptRequestSchema, declineRequestSchema };
+const blockUserSchema = z.object({
+  blockedId: z
+    .string({ required_error: 'El ID del usuario a bloquear es obligatorio' })
+    .uuid('El ID del usuario a bloquear no es válido'),
+});
+
+module.exports = { sendRequestSchema, acceptRequestSchema, declineRequestSchema, blockUserSchema };

--- a/src/modules/friends/friends.service.js
+++ b/src/modules/friends/friends.service.js
@@ -95,6 +95,42 @@ const friendsService = {
     throw new AppError(409, 'No existe una solicitud de amistad válida para rechazar');
   },
 
+  // H8 CA.2: bloquea a blockedId. CA.3: rompe la amistad existente si la hay.
+  // CA.1: no se notifica al bloqueado.
+  async blockUser(blockerId, blockedId) {
+    if (blockerId === blockedId) {
+      throw new AppError(400, 'No podés bloquearte a vos mismo');
+    }
+
+    // Crear el bloqueo (ON CONFLICT DO NOTHING: idempotente si ya estaba bloqueado)
+    await friendsRepository.createBlock(blockerId, blockedId);
+
+    // CA.3: si existía una amistad (pendiente o aceptada), eliminarla lógicamente
+    await friendsRepository.softDeleteFriendshipByPair(blockerId, blockedId);
+
+    return { message: 'Usuario bloqueado' };
+  },
+
+  // H8 CA.2: desbloquea a blockedId.
+  async unblockUser(blockerId, blockedId) {
+    if (blockerId === blockedId) {
+      throw new AppError(400, 'Operación inválida');
+    }
+
+    const deleted = await friendsRepository.deleteBlock(blockerId, blockedId);
+    if (!deleted) {
+      throw new AppError(404, 'No tenés bloqueado a este usuario');
+    }
+
+    return { message: 'Usuario desbloqueado' };
+  },
+
+  // H8 CA.2: lista de usuarios bloqueados por el usuario autenticado.
+  async getBlockedUsers(blockerId) {
+    const blocked = await friendsRepository.getBlockedUserIds(blockerId);
+    return { data: blocked };
+  },
+
   // CA.3/CA.5: lista paginada de solicitudes pendientes ordenadas descendente.
   // CA.4 (filtrar emisores con cuenta eliminada/suspendida) no está implementado:
   // requiere un endpoint en el servicio de usuarios que aún no existe.


### PR DESCRIPTION
Logica backend de bloqueo de usuarios, exceptuando ca4 y ca5 que no se pueden implementar por dependencias. Crea 3 endpoints nuevos: `POST /api/friends/block`, `DELETE/api/friends/block/:blockedId`, y `GET /api/friends/blocks `. Incluye soft delete en amabs direcciones para entradas de amigos en la bd, y tests unitarios de los comportamientos.