### PR TITLE
Conexion users h4

### DIFF
--- a/src/modules/friends/__tests__/friends.service.test.js
+++ b/src/modules/friends/__tests__/friends.service.test.js
@@ -11,6 +11,7 @@ jest.mock('../friends.repository', () => ({
     acceptById: jest.fn(),
     removeByPair: jest.fn(),
     softDeleteById: jest.fn(),
+    softDeleteAllByUserId: jest.fn(),
     getPendingRequesterIds: jest.fn(),
     getPendingRequests: jest.fn(),
     getConfirmedFriends: jest.fn(),
@@ -658,5 +659,51 @@ describe('friendsService.getFriendsList', () => {
     const result = await friendsService.getFriendsList(REQUESTER_ID);
 
     expect(result.pagination.page).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteUserRelationships — H4 CA.2/CA.4
+// ---------------------------------------------------------------------------
+describe('friendsService.deleteUserRelationships', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // Caso principal: el usuario tiene relaciones activas
+  it('H4 CA.2/CA.4: llama a softDeleteAllByUserId con el userId correcto', async () => {
+    friendsRepository.softDeleteAllByUserId.mockResolvedValue(3);
+
+    await friendsService.deleteUserRelationships(REQUESTER_ID);
+
+    expect(friendsRepository.softDeleteAllByUserId).toHaveBeenCalledWith(REQUESTER_ID);
+  });
+
+  it('H4 CA.2/CA.4: devuelve el conteo de relaciones eliminadas', async () => {
+    friendsRepository.softDeleteAllByUserId.mockResolvedValue(3);
+
+    const result = await friendsService.deleteUserRelationships(REQUESTER_ID);
+
+    expect(result).toEqual({ deleted: 3 });
+  });
+
+  // Caso sin relaciones previas
+  it('H4: devuelve { deleted: 0 } si el usuario no tenía relaciones activas', async () => {
+    friendsRepository.softDeleteAllByUserId.mockResolvedValue(0);
+
+    const result = await friendsService.deleteUserRelationships(REQUESTER_ID);
+
+    expect(result).toEqual({ deleted: 0 });
+  });
+
+  // No debe llamar a ningún otro método del repositorio
+  it('H4: no consulta ni modifica otras entidades del repositorio', async () => {
+    friendsRepository.softDeleteAllByUserId.mockResolvedValue(0);
+
+    await friendsService.deleteUserRelationships(REQUESTER_ID);
+
+    expect(friendsRepository.findByPair).not.toHaveBeenCalled();
+    expect(friendsRepository.softDeleteById).not.toHaveBeenCalled();
+    expect(friendsRepository.removeByPair).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/friends/friends.controller.js
+++ b/src/modules/friends/friends.controller.js
@@ -68,6 +68,16 @@ const friendsController = {
       next(err);
     }
   },
+  // H4: llamado por el microservicio users al eliminar una cuenta.
+  // Elimina lógicamente todas las relaciones del usuario (accepted + pending, ambas direcciones).
+  async deleteUserRelationships(req, res, next) {
+    try {
+      const result = await friendsService.deleteUserRelationships(req.params.userId);
+      res.status(200).json(result);
+    } catch (err) {
+      next(err);
+    }
+  },
 };
 
 module.exports = { friendsController };

--- a/src/modules/friends/friends.repository.js
+++ b/src/modules/friends/friends.repository.js
@@ -118,6 +118,19 @@ const friendsRepository = {
     return { rows: result.rows, total };
   },
 
+  // H4 CA.2/CA.4: soft-delete de todas las relaciones (accepted o pending) de un usuario eliminado.
+  async softDeleteAllByUserId(userId) {
+    const result = await query(
+      `UPDATE friends
+       SET deleted_at = NOW(), updated_at = NOW()
+       WHERE (requester_id = $1 OR addressee_id = $1)
+         AND deleted_at IS NULL
+       RETURNING id`,
+      [userId]
+    );
+    return result.rowCount;
+  },
+
   // CA.3/CA.5: devuelve solicitudes pendientes paginadas, filtradas por emisores activos.
   // Usa COUNT(*) OVER() para obtener el total real con los mismos filtros en una sola query.
   async getPendingRequests(addresseeId, activeRequesterIds, limit, offset) {

--- a/src/modules/friends/friends.routes.js
+++ b/src/modules/friends/friends.routes.js
@@ -25,4 +25,8 @@ router.get('/pending', authenticate, friendsController.getPendingRequests);
 // H7 CA.1: lista de amigos confirmados ordenada | CA.2: paginada (20 por página)
 router.get('/', authenticate, friendsController.getFriendsList);
 
+// DELETE /api/friends/user/:userId  — llamado internamente por el microservicio users (H4 CA.2/CA.4)
+// Elimina lógicamente todas las relaciones del usuario (accepted + pending, ambas direcciones)
+router.delete('/user/:userId', friendsController.deleteUserRelationships);
+
 module.exports = router;

--- a/src/modules/friends/friends.service.js
+++ b/src/modules/friends/friends.service.js
@@ -175,6 +175,12 @@ const friendsService = {
       },
     };
   },
+  // H4 CA.2/CA.4: elimina lógicamente todas las relaciones de amistad del usuario,
+  // tanto las aceptadas como las solicitudes pendientes (en ambas direcciones).
+  async deleteUserRelationships(userId) {
+    const count = await friendsRepository.softDeleteAllByUserId(userId);
+    return { deleted: count };
+  },
 };
 
 module.exports = { friendsService };


### PR DESCRIPTION
@MateoCostantini @delfinachavez @Tomicarrie 
Crea nuevo endpoint `DELETE /api/friends/user/:userId` para ser llamado por otros microservicios, que permite eliminar las relaciones de amistad dado un userId