### PR TITLE
H11-Friends

### DIFF
--- a/src/clients/usersClient.js
+++ b/src/clients/usersClient.js
@@ -34,6 +34,35 @@ const usersClient = {
     const data = await response.json();
     return data.activeUserIds;
   },
+
+  // H10 CA.1: consulta al servicio de usuarios cuáles de los IDs dados
+  // estuvieron activos en los últimos 5 minutos (last_seen_at reciente).
+  // Devuelve un Set de strings para hacer lookup en O(1) al armar la lista.
+  // Si el servicio no está disponible, falla silenciosamente y devuelve Set vacío
+  // para no romper la lista de amigos por un error de presencia.
+  async getOnlineStatus(userIds) {
+    if (!userIds || userIds.length === 0) return new Set();
+
+    const url = `${process.env.USERS_SERVICE_URL}/internal/users/online-status`;
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userIds }),
+      });
+
+      if (!response.ok) {
+        console.warn(`[usersClient] getOnlineStatus responded ${response.status}`);
+        return new Set();
+      }
+
+      const data = await response.json();
+      return new Set(data.onlineIds || []);
+    } catch (err) {
+      console.warn('[usersClient] getOnlineStatus failed, defaulting to all offline:', err.message);
+      return new Set();
+    }
+  },
 };
 
 module.exports = { usersClient };

--- a/src/modules/friends/friends.service.js
+++ b/src/modules/friends/friends.service.js
@@ -1,5 +1,6 @@
 const { friendsRepository } = require('./friends.repository');
 const { AppError } = require('../../middlewares/errorHandler');
+const { usersClient } = require('../../clients/usersClient');
 
 const REQUEST_LIMIT_PER_HOUR = 20;
 const PAGE_SIZE = 20;
@@ -120,6 +121,7 @@ const friendsService = {
   // H7 CA.1: lista paginada de amigos confirmados.
   // sortBy='alphabetical': ordena por username del amigo (A-Z).
   // sortBy='proximity': devuelve 501 — requiere integración con servicio de ubicaciones (pendiente).
+  // H10 CA.1/CA.2: enriquece cada amigo con is_online (true si estuvo activo en los últimos 5 min).
   async getFriendsList(userId, sortBy = 'alphabetical', page = 1) {
     if (sortBy === 'proximity') {
       throw new AppError(501, 'Ordenamiento por cercanía aún no está disponible');
@@ -130,8 +132,21 @@ const friendsService = {
 
     const { rows, total } = await friendsRepository.getConfirmedFriends(userId, limit, offset);
 
+    // H10 CA.1: consultar online-status para los amigos de esta página.
+    // Si USERS_SERVICE_URL no está configurado (entorno sin inter-servicios), se salta.
+    let onlineSet = new Set();
+    if (process.env.USERS_SERVICE_URL && rows.length > 0) {
+      const friendIds = rows.map((r) => r.friend_id);
+      onlineSet = await usersClient.getOnlineStatus(friendIds);
+    }
+
+    const enrichedRows = rows.map((r) => ({
+      ...r,
+      is_online: onlineSet.has(r.friend_id),
+    }));
+
     return {
-      data: rows,
+      data: enrichedRows,
       pagination: {
         page,
         pageSize: limit,

--- a/tests/unit/friends.service.test.js
+++ b/tests/unit/friends.service.test.js
@@ -1,7 +1,14 @@
 const { friendsService } = require('../../src/modules/friends/friends.service');
 const { friendsRepository } = require('../../src/modules/friends/friends.repository');
 const { AppError } = require('../../src/middlewares/errorHandler');
+const { usersClient } = require('../../src/clients/usersClient');
 
+jest.mock('../../src/clients/usersClient', () => ({
+  usersClient: {
+    getOnlineStatus: jest.fn(),
+    getActiveUserIds: jest.fn(),
+  },
+}));
 jest.mock('../../src/modules/friends/friends.repository', () => ({
   friendsRepository: {
     countRequestsInLastHour: jest.fn(),

--- a/tests/unit/friends.service.test.js
+++ b/tests/unit/friends.service.test.js
@@ -1042,3 +1042,85 @@ describe('friendsService.getFriendIds', () => {
     expect(result.friendIds).toEqual(ids);
   });
 });
+
+// ---------------------------------------------------------------------------
+// H11 CA.1/CA.2: getFriendsList — enriquecimiento is_online
+// ---------------------------------------------------------------------------
+describe('friendsService.getFriendsList — is_online (H11)', () => {
+  const makeFriend = (friendId, friendUsername) => ({
+    friend_id: friendId,
+    friend_username: friendUsername,
+    total_count: '1',
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.USERS_SERVICE_URL = 'http://users-service';
+    usersClient.getOnlineStatus.mockResolvedValue(new Set());
+  });
+
+  afterEach(() => {
+    delete process.env.USERS_SERVICE_URL;
+  });
+
+  it('CA.1: marca is_online true para el amigo cuyo ID devuelve usersClient', async () => {
+    const friend = makeFriend(ADDRESSEE_ID, 'alice');
+    friendsRepository.getConfirmedFriends.mockResolvedValue({ rows: [friend], total: 1 });
+    usersClient.getOnlineStatus.mockResolvedValue(new Set([ADDRESSEE_ID]));
+
+    const result = await friendsService.getFriendsList(REQUESTER_ID, 'alphabetical', 1);
+
+    expect(result.data[0].is_online).toBe(true);
+  });
+
+  it('CA.1: marca is_online false si el amigo no está en el Set', async () => {
+    const friend = makeFriend(ADDRESSEE_ID, 'alice');
+    friendsRepository.getConfirmedFriends.mockResolvedValue({ rows: [friend], total: 1 });
+    usersClient.getOnlineStatus.mockResolvedValue(new Set());
+
+    const result = await friendsService.getFriendsList(REQUESTER_ID, 'alphabetical', 1);
+
+    expect(result.data[0].is_online).toBe(false);
+  });
+
+  it('CA.1: diferencia correctamente online/offline en una lista mixta', async () => {
+    const THIRD_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+    const friendA = makeFriend(ADDRESSEE_ID, 'alice');
+    const friendB = makeFriend(THIRD_ID, 'bob');
+    friendsRepository.getConfirmedFriends.mockResolvedValue({ rows: [friendA, friendB], total: 2 });
+    usersClient.getOnlineStatus.mockResolvedValue(new Set([ADDRESSEE_ID]));
+
+    const result = await friendsService.getFriendsList(REQUESTER_ID, 'alphabetical', 1);
+
+    expect(result.data.find((f) => f.friend_id === ADDRESSEE_ID).is_online).toBe(true);
+    expect(result.data.find((f) => f.friend_id === THIRD_ID).is_online).toBe(false);
+  });
+
+  it('CA.1: llama a usersClient.getOnlineStatus con los IDs de los amigos de la página', async () => {
+    const friend = makeFriend(ADDRESSEE_ID, 'alice');
+    friendsRepository.getConfirmedFriends.mockResolvedValue({ rows: [friend], total: 1 });
+
+    await friendsService.getFriendsList(REQUESTER_ID, 'alphabetical', 1);
+
+    expect(usersClient.getOnlineStatus).toHaveBeenCalledWith([ADDRESSEE_ID]);
+  });
+
+  it('no llama a usersClient si USERS_SERVICE_URL no está configurado', async () => {
+    delete process.env.USERS_SERVICE_URL;
+    const friend = makeFriend(ADDRESSEE_ID, 'alice');
+    friendsRepository.getConfirmedFriends.mockResolvedValue({ rows: [friend], total: 1 });
+
+    const result = await friendsService.getFriendsList(REQUESTER_ID, 'alphabetical', 1);
+
+    expect(usersClient.getOnlineStatus).not.toHaveBeenCalled();
+    expect(result.data[0].is_online).toBe(false);
+  });
+
+  it('no llama a usersClient si la lista de amigos está vacía', async () => {
+    friendsRepository.getConfirmedFriends.mockResolvedValue({ rows: [], total: 0 });
+
+    await friendsService.getFriendsList(REQUESTER_ID, 'alphabetical', 1);
+
+    expect(usersClient.getOnlineStatus).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/friends.service.test.js
+++ b/tests/unit/friends.service.test.js
@@ -648,13 +648,13 @@ describe('friendsService.getFriendsList', () => {
     expect(result.pagination.totalPages).toBe(1);
   });
 
-  it('CA.2: devuelve los datos del amigo tal como los provee el repository', async () => {
+  it('CA.2: devuelve los datos del amigo y los setea con is_online', async () => {
     const friend = makeFriend(ADDRESSEE_ID, 'alice');
     friendsRepository.getConfirmedFriends.mockResolvedValue({ rows: [friend], total: 1 });
 
     const result = await friendsService.getFriendsList(REQUESTER_ID, 'alphabetical', 1);
 
-    expect(result.data).toEqual([friend]);
+    expect(result.data).toEqual([{ ...friend, is_online: false }]);
   });
 
   it('CA.2: usa page 1 por defecto si no se pasa parámetro', async () => {


### PR DESCRIPTION
COMO usuario del sistema
QUIERO ver quiénes de mis amigos están conectados
PARA saber quién está usando la app en el momento.
CA.1: Un usuario se considera "en línea" si interactuó con la app en los
últimos 5 minutos.
CA.2: Debe mostrarse un indicador visual (ej. punto verde) en la foto de
perfil del listado.
CA.3: Si el usuario tiene activado el "Modo Fantasma" (H4), debe
aparecer siempre como desconectado (sin el punto verde) para sus
amigos, independientemente de si está usando la app o no.