### PR TITLE
deuda tecnica: descartar denuncias

### DIFF
--- a/src/modules/reports/reports.internal.controller.js
+++ b/src/modules/reports/reports.internal.controller.js
@@ -29,6 +29,16 @@ const reportsInternalController = {
     }
   },
 
+  async discardReport(req, res, next) {
+    try {
+      const { reportId } = req.params;
+      await reportsRepository.discardReport(reportId);
+      res.json({ message: 'Denuncia descartada.' });
+    } catch (err) {
+      next(err);
+    }
+  },
+
   // H7 CA.2: resolver — marca reportes como 'resolved'
   async resolve(req, res, next) {
     try {

--- a/src/modules/reports/reports.internal.routes.js
+++ b/src/modules/reports/reports.internal.routes.js
@@ -8,5 +8,6 @@ const router = Router();
 router.get('/reports', authenticateInternal, reportsInternalController.list);
 router.post('/reports/:reportedId/discard', authenticateInternal, reportsInternalController.discard);
 router.post('/reports/:reportedId/resolve', authenticateInternal, reportsInternalController.resolve);
+router.post('/reports/report/:reportId/discard', authenticateInternal, reportsInternalController.discardReport);
 
 module.exports = router;

--- a/src/modules/reports/reports.repository.js
+++ b/src/modules/reports/reports.repository.js
@@ -29,10 +29,19 @@ const reportsRepository = {
   async countDistinctReporters(reportedId, since = null) {
     const result = await query(
       `SELECT COUNT(DISTINCT reporter_id) as count FROM reports
-       WHERE reported_id = $1 AND ($2::timestamptz IS NULL OR created_at > $2)`,
+       WHERE reported_id = $1
+         AND status != 'discarded'
+         AND ($2::timestamptz IS NULL OR created_at > $2)`,
       [reportedId, since]
     );
     return parseInt(result.rows[0].count, 10);
+  },
+
+  async discardReport(reportId) {
+    await query(
+      "UPDATE reports SET status = 'discarded' WHERE id = $1 AND status = 'pending'",
+      [reportId]
+    );
   },
 
   // H7: listado agrupado por usuario denunciado para el panel de administración

--- a/tests/unit/reports.internal.controller.test.js
+++ b/tests/unit/reports.internal.controller.test.js
@@ -6,10 +6,12 @@ jest.mock('../../src/modules/reports/reports.repository', () => ({
     listReportGroups:  jest.fn(),
     countReportGroups: jest.fn(),
     markReportsStatus: jest.fn(),
+    discardReport:     jest.fn(),
   },
 }));
 
 const REPORTED_ID = 'reported-uuid-1';
+const REPORT_ID   = 'report-uuid-1';
 
 const SAMPLE_GROUP = {
   reported_id:        REPORTED_ID,
@@ -23,7 +25,7 @@ const SAMPLE_GROUP = {
 };
 
 function makeReq(overrides = {}) {
-  return { params: { reportedId: REPORTED_ID }, query: {}, ...overrides };
+  return { params: { reportedId: REPORTED_ID, reportId: REPORT_ID }, query: {}, ...overrides };
 }
 function makeRes() { return { json: jest.fn() }; }
 function makeNext() { return jest.fn(); }
@@ -124,6 +126,33 @@ describe('reportsInternalController.resolve', () => {
     reportsRepository.markReportsStatus.mockRejectedValue(new Error('DB error'));
     const next = makeNext();
     await reportsInternalController.resolve(makeReq(), makeRes(), next);
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+  });
+});
+
+// ─── discardReport ────────────────────────────────────────────────────────────
+
+describe('reportsInternalController.discardReport', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    reportsRepository.discardReport.mockResolvedValue();
+  });
+
+  it('llama a reportsRepository.discardReport con el reportId', async () => {
+    await reportsInternalController.discardReport(makeReq(), makeRes(), makeNext());
+    expect(reportsRepository.discardReport).toHaveBeenCalledWith(REPORT_ID);
+  });
+
+  it('devuelve un mensaje de confirmación', async () => {
+    const res = makeRes();
+    await reportsInternalController.discardReport(makeReq(), res, makeNext());
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ message: expect.any(String) }));
+  });
+
+  it('llama a next con el error si discardReport falla', async () => {
+    reportsRepository.discardReport.mockRejectedValue(new Error('DB error'));
+    const next = makeNext();
+    await reportsInternalController.discardReport(makeReq(), makeRes(), next);
     expect(next).toHaveBeenCalledWith(expect.any(Error));
   });
 });

--- a/tests/unit/reports.repository.test.js
+++ b/tests/unit/reports.repository.test.js
@@ -6,9 +6,86 @@ jest.mock('../../src/config/database', () => ({
 }));
 
 const REPORTED_ID = 'reported-uuid-1';
+const REPORT_ID   = 'report-uuid-1';
 
 beforeEach(() => {
   jest.clearAllMocks();
+});
+
+// ─── countDistinctReporters ───────────────────────────────────────────────────
+
+describe('reportsRepository.countDistinctReporters', () => {
+  beforeEach(() => {
+    query.mockResolvedValue({ rows: [{ count: '3' }] });
+  });
+
+  it('excluye reportes con status = discarded del conteo', async () => {
+    await reportsRepository.countDistinctReporters(REPORTED_ID);
+
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining("status != 'discarded'"),
+      expect.any(Array)
+    );
+  });
+
+  it('cuenta solo para el reported_id indicado', async () => {
+    await reportsRepository.countDistinctReporters(REPORTED_ID);
+
+    expect(query).toHaveBeenCalledWith(
+      expect.any(String),
+      [REPORTED_ID, null]
+    );
+  });
+
+  it('pasa el timestamp since cuando se provee', async () => {
+    const since = '2026-01-01T00:00:00.000Z';
+    await reportsRepository.countDistinctReporters(REPORTED_ID, since);
+
+    expect(query).toHaveBeenCalledWith(
+      expect.any(String),
+      [REPORTED_ID, since]
+    );
+  });
+
+  it('devuelve el conteo como número entero', async () => {
+    const result = await reportsRepository.countDistinctReporters(REPORTED_ID);
+    expect(result).toBe(3);
+  });
+});
+
+// ─── discardReport ────────────────────────────────────────────────────────────
+
+describe('reportsRepository.discardReport', () => {
+  beforeEach(() => {
+    query.mockResolvedValue({ rowCount: 1 });
+  });
+
+  it('ejecuta UPDATE con el reportId correcto', async () => {
+    await reportsRepository.discardReport(REPORT_ID);
+
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE reports'),
+      [REPORT_ID]
+    );
+  });
+
+  it("solo actualiza filas con status = 'pending'", async () => {
+    await reportsRepository.discardReport(REPORT_ID);
+
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining("status = 'pending'"),
+      expect.any(Array)
+    );
+  });
+
+  it("establece status = 'discarded'", async () => {
+    await reportsRepository.discardReport(REPORT_ID);
+
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining("status = 'discarded'"),
+      expect.any(Array)
+    );
+  });
 });
 
 // ─── listReportGroups ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Permite descartar denuncias individuales en lugar de descartar todas juntas. Marca como "discarded" en la base de datos y no las cuenta para el conteo que luego bloquea acceso cuando se superan las 5 denuncias.